### PR TITLE
Add gtk-common-themes plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -70,3 +70,17 @@ apps:
       - unity7
       - wayland
       - x11
+
+plugs:
+  gtk-3-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes


### PR DESCRIPTION
As per discussion with desktop team, I'm adding plugs stanzas to re-use themes from the gtk-common-themes snap.