### PR TITLE
Ensure we only get one deb url

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,7 @@ parts:
       wget --quiet https://api.github.com/repos/Automattic/simplenote-electron/releases/latest -O releases.json
       # Get the version from the tag_name and the download URL.
       VERSION=$(jq . releases.json | grep tag_name | cut -d'"' -f4 | sed s'/v//')
-      DEB_URL=$(cat releases.json | jq -r ".assets[] | select(.name | test(\"deb\")) | .browser_download_url"| grep $(dpkg --print-architecture)
+      DEB_URL=$(cat releases.json | jq -r ".assets[] | select(.name | test(\"deb\")) | .browser_download_url"| grep $(dpkg --print-architecture))
       DEB=$(basename "${DEB_URL}")
       echo "Downloading ${DEB_URL}..."
       wget --quiet "${DEB_URL}" -O "${SNAPCRAFT_PART_INSTALL}/${DEB}"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,6 +5,10 @@ description: |
  notes stay in sync with all of your devices for free.
 adopt-info: simplenote
 
+architectures:
+  - build-on: amd64
+  - build-on: i386
+
 grade: stable
 confinement: strict
 
@@ -32,13 +36,9 @@ parts:
     after:
       - desktop-gtk2
     build-packages:
-      # Simplenote debs are only available for amd64.
-      # Fail builds on other architectures
-      - on amd64:
-        - dpkg
-        - jq
-        - wget
-      - else fail
+      - dpkg
+      - jq
+      - wget
     stage-packages:
       - libasound2
       - libgconf2-4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,7 @@ parts:
       wget --quiet https://api.github.com/repos/Automattic/simplenote-electron/releases/latest -O releases.json
       # Get the version from the tag_name and the download URL.
       VERSION=$(jq . releases.json | grep tag_name | cut -d'"' -f4 | sed s'/v//')
-      DEB_URL=$(cat releases.json | jq -r ".assets[] | select(.name | test(\"deb\")) | .browser_download_url")
+      DEB_URL=$(cat releases.json | jq -r ".assets[] | select(.name | test(\"deb\")) | .browser_download_url"| grep $(dpkg --print-architecture)
       DEB=$(basename "${DEB_URL}")
       echo "Downloading ${DEB_URL}..."
       wget --quiet "${DEB_URL}" -O "${SNAPCRAFT_PART_INSTALL}/${DEB}"


### PR DESCRIPTION
Currently, the releases file contains multiple deb URLs (one per arch) which fails the build script because wget tries to pull both debs. This PR greps for only the current arch in the releases file.