### PR TITLE
Move to gtk3 launcher

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
       snapcraftctl set-version "$VERSION"
       sed -i 's|Icon=simplenote|Icon=/usr/share/icons/hicolor/256x256/apps/simplenote\.png|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/simplenote.desktop
     after:
-      - desktop-gtk2
+      - desktop-gtk3
     build-packages:
       - dpkg
       - jq


### PR DESCRIPTION
Simplenote is now using electron 2 which needs a migration to gtk3. This should fix #15