### PR TITLE
Update snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,6 +32,9 @@ plugs:
     default-provider: gtk-common-themes
 
 parts:
+  bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
+    plugin: nil
+    source: https://github.com/Automattic/simplenote-electron.git
   desktop-gnome-platform:
     source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
     source-subdir: gtk


### PR DESCRIPTION
A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes