### PR TITLE
Migrate to GNOME 3.28 platform snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -58,6 +58,14 @@ parts:
       - libnspr4
       - libnss3
       - libxss1
+  cleanup:
+    after: [simplenote]
+    plugin: nil
+    build-snaps: [ gnome-3-28-1804 ]
+    override-prime: |
+        set -eux
+        cd /snap/gnome-3-28-1804/current
+        find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
 
 apps:
   simplenote:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,14 +77,9 @@ apps:
     plugs:
       - browser-support
       - cups-control
-      - desktop
-      - desktop-legacy
-      - gsettings
       - home
-      - mount-observe
       - network
       - opengl
       - pulseaudio
+      - removable-media
       - unity7
-      - wayland
-      - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,35 +13,11 @@ architectures:
 grade: stable
 confinement: strict
 
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/data-dir/themes
-    default-provider: gtk-common-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/data-dir/icons
-    default-provider: gtk-common-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/data-dir/sounds
-    default-provider: gtk-common-themes
-
 parts:
   bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
     plugin: nil
     source: https://github.com/Automattic/simplenote-electron.git
-  desktop-gnome-platform:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: gtk
-    plugin: make
-    make-parameters: ["FLAVOR=gtk3"]
-    build-packages:
-      - libgtk-3-dev
+
   libappindicator:
     plugin: nil
     stage-packages:
@@ -52,6 +28,7 @@ parts:
       - usr/lib/$SNAPCRAFT_ARCH_TRIPLET/libindicator*.so*
 
   simplenote:
+    after: [libappindicator]
     plugin: nil
     override-build: |
       set -x
@@ -72,15 +49,11 @@ parts:
       rm -f "${SNAPCRAFT_PART_INSTALL}/opt/Simplenote/chrome-sandbox" 2>/dev/null
       snapcraftctl set-version "$VERSION"
       sed -i 's|Icon=simplenote|Icon=/usr/share/icons/hicolor/256x256/apps/simplenote\.png|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/simplenote.desktop
-    after:
-      - desktop-gnome-platform
-      - libappindicator
     build-packages:
       - dpkg
       - jq
       - wget
     stage-packages:
-      - libasound2
       - libgconf2-4
       - libnspr4
       - libnss3
@@ -88,8 +61,9 @@ parts:
 
 apps:
   simplenote:
-    command: bin/desktop-launch $SNAP/opt/Simplenote/simplenote --no-sandbox
+    command: opt/Simplenote/simplenote --no-sandbox
     desktop: usr/share/applications/simplenote.desktop
+    extensions: [gnome-3-28]
     environment:
       # Correct the TMPDIR path for Chromium Framework/Electron to
       # ensure libappindicator has readable resources


### PR DESCRIPTION
The pull request migrates to the GNOME 3.28 platform snap and reduces the size of the snap by ~20MB.