### PR TITLE
Allow for arm64 builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,11 +21,15 @@ platforms:
   amd64:
     build-on: [amd64]
     build-for: [amd64]
+  arm64:
+    build-on: [arm64]
+    build-for: [arm64]
 
 parts:
   simplenote:
     source: 
       - on amd64: https://github.com/Automattic/simplenote-electron/releases/download/v${SNAPCRAFT_PROJECT_VERSION}/Simplenote-linux-${SNAPCRAFT_PROJECT_VERSION}-x64.tar.gz
+      - on arm64: https://github.com/Automattic/simplenote-electron/releases/download/v${SNAPCRAFT_PROJECT_VERSION}/Simplenote-linux-${SNAPCRAFT_PROJECT_VERSION}-arm64.tar.gz
     plugin: dump
     prime:
       - -chrome-sandbox


### PR DESCRIPTION
I just got this running on my M2 Macbook Air running Ubuntu Asahi, and it seems fine from first glance. I'm sure that's a weird corner case to support officially, but it might be worth having for people who want to build and use Simplenote in an unsupported capacity for arm64 :)